### PR TITLE
Fix build error

### DIFF
--- a/gorep.go
+++ b/gorep.go
@@ -3,9 +3,9 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/go.crypto/ssh/terminal"
 	"flag"
 	"fmt"
+	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"os"
 	"path"
@@ -426,7 +426,7 @@ func (this *gorep) grep(fpath string, out chan<- grepInfo) {
 		return
 	}
 
-	buffer  := bytes.NewBuffer(mem)
+	buffer := bytes.NewBuffer(mem)
 	scanner := bufio.NewScanner(buffer)
 
 	scanner.Split(bufio.ScanLines)


### PR DESCRIPTION
I was looking for a grep tool written in Go for learning Go programming. And I found your repository.
I tryed "go get" command. But build error.

```bash
package code.google.com/p/go.crypto/ssh/terminal: unrecognized import path "code.google.com/p/go.crypto/ssh/terminal" (parse https://code.google.com/p/go.crypto/ssh/terminal?go-get=1: no go-import meta tags (meta tag github.com/golang/go did not match import path code.google.com/p/go.crypto/ssh/terminal)
```

As it seemed that it was necessary to correct the import path, I was fixed.

Thank you!
It's so cool project of gorep!